### PR TITLE
Cherrypick 'add security namespace to context for actor' from upstream

### DIFF
--- a/activity.go
+++ b/activity.go
@@ -45,6 +45,7 @@ var falsenames = []string{
 }
 
 const itiswhatitis = "https://www.w3.org/ns/activitystreams"
+const papersplease = "https://w3id.org/security/v1"
 const atContextString = "https://www.w3.org/ns/activitystreams#Public"
 const tinyworld = "as:Public"
 const chatKeyProp = "chatKeyV0"
@@ -1656,7 +1657,7 @@ func collectiveaction(honk *ActivityPubActivity) {
 
 func junkuser(user *WhatAbout) junk.Junk {
 	j := junk.New()
-	j["@context"] = itiswhatitis
+	j["@context"] = []string{itiswhatitis, papersplease}
 	j["id"] = user.URL
 	j["inbox"] = user.URL + "/inbox"
 	j["outbox"] = user.URL + "/outbox"


### PR DESCRIPTION
This fixes federation with AP implementations that perform JSON-LD expansion, e.g. [Iceshrimp.NET](https://iceshrimp.net) or [Takahe](https://github.com/jointakahe/takahe).

Untested, but given the simple nature of the change, and the fact that this patch (cherry-picked from [upstream](https://humungus.tedunangst.com/r/honk/v/317a99583340)) fixed this issue with the authors instance, I presume it works here as well.